### PR TITLE
fix nullpointers on close calls

### DIFF
--- a/jucx-binding/src/main/java/de/hhu/bsinfo/hadronio/jucx/JucxEndpoint.java
+++ b/jucx-binding/src/main/java/de/hhu/bsinfo/hadronio/jucx/JucxEndpoint.java
@@ -141,7 +141,9 @@ class JucxEndpoint implements UcxEndpoint {
     @Override
     public void close() {
         LOGGER.info("Closing endpoint");
-        endpoint.close();
+        if(endpoint != null) {
+            endpoint.close();
+        }
     }
 
     void handleError() {

--- a/jucx-binding/src/main/java/de/hhu/bsinfo/hadronio/jucx/JucxListener.java
+++ b/jucx-binding/src/main/java/de/hhu/bsinfo/hadronio/jucx/JucxListener.java
@@ -52,12 +52,18 @@ class JucxListener implements UcxListener {
 
     @Override
     public InetSocketAddress getAddress() {
-        return listener.getAddress();
+        if(listener == null) {
+            return null;
+        }else {
+            return listener.getAddress();
+        }
     }
 
     @Override
     public void close() {
         LOGGER.info("Closing listener");
-        listener.close();
+        if(listener != null) {
+            listener.close();
+        }
     }
 }


### PR DESCRIPTION
Currently testing with Netty in https://github.com/invesdwin/invesdwin-context-integration#synchronous-channels where these nullpointers occurred.