### PR TITLE
Fix issue with growing number of allocated direct buffers

### DIFF
--- a/core/src/main/java/de/hhu/bsinfo/hadronio/HadronioSocketChannel.java
+++ b/core/src/main/java/de/hhu/bsinfo/hadronio/HadronioSocketChannel.java
@@ -8,6 +8,7 @@ import de.hhu.bsinfo.hadronio.util.MemoryUtil.Alignment;
 import de.hhu.bsinfo.hadronio.util.MessageUtil;
 import de.hhu.bsinfo.hadronio.util.RingBuffer;
 import de.hhu.bsinfo.hadronio.util.TagUtil;
+import org.agrona.BufferUtil;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.AtomicBuffer;
 import org.agrona.concurrent.MessageHandler;
@@ -329,6 +330,7 @@ public class HadronioSocketChannel extends SocketChannel implements HadronioSele
         endpoint.close();
         sendBuffer.alignedBuffer().free();
         receiveBuffer.alignedBuffer().free();
+        BufferUtil.free(flushBuffer);
     }
 
     @Override
@@ -452,21 +454,23 @@ public class HadronioSocketChannel extends SocketChannel implements HadronioSele
     }
 
     void establishConnection() {
-        final var sendBuffer = new MemoryUtil.AlignedBuffer(2 * Long.BYTES, Alignment.PAGE).buffer();
-        final var receiveBuffer = new MemoryUtil.AlignedBuffer(2 * Long.BYTES, Alignment.PAGE).buffer();
+        final var sendBuffer = new MemoryUtil.AlignedBuffer(2 * Long.BYTES, Alignment.PAGE);
+        final var receiveBuffer = new MemoryUtil.AlignedBuffer(2 * Long.BYTES, Alignment.PAGE);
 
         final long localId = TagUtil.generateId();
         final long checksum = TagUtil.calculateChecksum(localId);
-        sendBuffer.putLong(0, localId);
-        sendBuffer.putLong(Long.BYTES, checksum);
+        sendBuffer.buffer().putLong(0, localId);
+        sendBuffer.buffer().putLong(Long.BYTES, checksum);
 
-        final var connectionCallback = new ConnectionCallback(this, receiveBuffer, localId);
+        final var connectionCallback = new ConnectionCallback(this, receiveBuffer.buffer(), localId);
         endpoint.setSendCallback(connectionCallback);
         endpoint.setReceiveCallback(connectionCallback);
 
         if (DebugConfig.DEBUG) LOGGER.debug("Exchanging tags to establish connection");
-        endpoint.sendStream(sendBuffer.addressOffset(), 2 * Long.BYTES, true, true);
-        endpoint.receiveStream(receiveBuffer.addressOffset(), 2 * Long.BYTES, true, false);
+        endpoint.sendStream(sendBuffer.buffer().addressOffset(), 2 * Long.BYTES, true, true);
+        endpoint.receiveStream(receiveBuffer.buffer().addressOffset(), 2 * Long.BYTES, true, false);
+        receiveBuffer.free();
+        sendBuffer.free();
     }
 
     private int readBlocking(final ByteBuffer target) throws IOException {

--- a/core/src/main/java/de/hhu/bsinfo/hadronio/ReceiveCallback.java
+++ b/core/src/main/java/de/hhu/bsinfo/hadronio/ReceiveCallback.java
@@ -3,6 +3,7 @@ package de.hhu.bsinfo.hadronio;
 import de.hhu.bsinfo.hadronio.binding.UcxReceiveCallback;
 import de.hhu.bsinfo.hadronio.generated.DebugConfig;
 import de.hhu.bsinfo.hadronio.util.TagUtil;
+import org.agrona.BufferUtil;
 import org.agrona.concurrent.AtomicBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
@@ -30,7 +31,7 @@ class ReceiveCallback implements UcxReceiveCallback {
         this.isFlushing = isFlushing;
         this.flushIntervalSize = flushIntervalSize;
 
-        flushBuffer = new UnsafeBuffer(ByteBuffer.allocateDirect(Long.BYTES));
+        flushBuffer = new UnsafeBuffer(ByteBuffer.allocate(Long.BYTES));
         flushBuffer.putLong(0, HadronioSocketChannel.FLUSH_ANSWER);
     }
 


### PR DESCRIPTION
Example showing the problematic scenario is here in master branch [kochkozharov/hadroNIO-memory-leak](https://github.com/kochkozharov/hadroNIO-memory-leak). It's pretty much the same as in my previous PR.
`docker compose -f docker-compose.nofix.yml up --build`
You can see unlimited growing number of off-heap buffers, which can cause OOM error or hang.
There are some charts from visualvm (shows memory usage and amount of direct buffers in client):
![server_nofix](https://github.com/user-attachments/assets/0e3edade-d991-48f3-978a-6bb89d6baa16)
Same situation appears in server.
In this fix I suggest to implicitly free objects like `new UnsafeBuffer(ByteBuffer.allocateDirect(Long.BYTES))` and replace direct buffer in callback with on-heap one.
Running the cluster with the changes:
`docker compose up --build`
Visualvm results in client:
![server_fix](https://github.com/user-attachments/assets/931e1af0-d19e-4420-92c7-3255acbbaca3)
The number of direct buffers has been significantly reduced.

